### PR TITLE
Add multiple database support

### DIFF
--- a/lib/replica_pools.rb
+++ b/lib/replica_pools.rb
@@ -3,12 +3,14 @@ require 'replica_pools/config'
 require 'replica_pools/pool'
 require 'replica_pools/pools'
 require 'replica_pools/active_record_extensions'
+require 'replica_pools/active_record_abstract_adapter_extensions'
 require 'replica_pools/hijack'
 require 'replica_pools/query_cache'
 require 'replica_pools/connection_proxy'
 
 require 'replica_pools/engine' if defined? Rails
 ActiveRecord::Base.send :include, ReplicaPools::ActiveRecordExtensions
+ActiveRecord::ConnectionAdapters::AbstractAdapter.send :prepend, ReplicaPools::ActiveRecordAbstractAdapterExtensions
 
 module ReplicaPools
   class << self

--- a/lib/replica_pools.rb
+++ b/lib/replica_pools.rb
@@ -28,7 +28,8 @@ module ReplicaPools
     end
 
     def create_proxy(klass, db_name)
-      proxies[db_name] ||= ReplicaPools::ConnectionProxy.new(klass, ReplicaPools.pools[db_name])
+      raise "Connection pools for #{db_name} not found" if pools[db_name].empty?
+      proxies[db_name] ||= ReplicaPools::ConnectionProxy.new(klass, pools[db_name])
     end
 
     def fetch_proxy(db_name)

--- a/lib/replica_pools.rb
+++ b/lib/replica_pools.rb
@@ -27,13 +27,9 @@ module ReplicaPools
       Thread.current[:replica_pools_proxies] ||= {}
     end
 
-    def create_proxy(klass, db_name)
+    def proxy(klass, db_name)
       raise "Connection pools for #{db_name} not found" if pools[db_name].empty?
       proxies[db_name] ||= ReplicaPools::ConnectionProxy.new(klass, pools[db_name])
-    end
-
-    def fetch_proxy(db_name)
-      proxies[db_name]
     end
 
     def pools

--- a/lib/replica_pools/active_record_abstract_adapter_extensions.rb
+++ b/lib/replica_pools/active_record_abstract_adapter_extensions.rb
@@ -1,0 +1,10 @@
+module ReplicaPools
+  module ActiveRecordAbstractAdapterExtensions
+    attr_accessor :host_name
+
+    def log(sql, name = "SQL", *other_args, &block)
+      name = "[ReplicaPools: #{host_name}] #{name}" if host_name
+      super(sql, name, *other_args, &block)
+    end
+  end
+end

--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -5,23 +5,63 @@ module ReplicaPools
     end
 
     def reload(options = nil)
-      self.class.connection_proxy.with_leader { super }
+      return super unless self.class.replica_pools_enabled?
+      self.class.with_leader { super }
     end
 
     module ClassMethods
+      def hijack_connection
+        class << self
+          alias_method :connection, :connection_proxy
+        end
+      end
+
+      def use_replica_pools(db_name)
+        @replica_pools_db_name = db_name
+        ReplicaPools.create_proxy(self, db_name)
+        hijack_connection
+      end
+
       def connection_proxy
-        ReplicaPools.proxy
+        ReplicaPools.fetch_proxy(replica_pools_db_name)
+      end
+
+      def with_pool(*a)
+        connection_proxy.with_pool(*a){ yield }
+      end
+
+      def with_leader
+        connection_proxy.with_leader{ yield }
+      end
+
+      def current_connection
+        connection_proxy.current
+      end
+
+      def next_replica!
+        connection_proxy.next_replica!
+      end
+
+      def replica_pools_enabled?
+        !!replica_pools_db_name
+      end
+
+      def replica_pools_db_name
+        replica_pools_own_db_name || replica_pools_closest_ancestor_db_name
+      end
+
+      def replica_pools_own_db_name
+        @replica_pools_db_name
+      end
+
+      def replica_pools_closest_ancestor_db_name
+        ancestors.select{ |k| k <= ActiveRecord::Base }.map(&:replica_pools_own_db_name).compact.first
       end
 
       # Make sure transactions run on leader
-      # Even if they're initiated from ActiveRecord::Base
-      # (which doesn't have our hijack).
       def transaction(options = {}, &block)
-        if self.connection.kind_of?(ConnectionProxy)
-          super
-        else
-          self.connection_proxy.with_leader { super }
-        end
+        return super unless replica_pools_enabled?
+        self.with_leader { super }
       end
     end
   end

--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -18,12 +18,11 @@ module ReplicaPools
 
       def use_replica_pools(db_name)
         @replica_pools_db_name = db_name
-        ReplicaPools.create_proxy(self, db_name)
         hijack_connection
       end
 
       def connection_proxy
-        ReplicaPools.fetch_proxy(replica_pools_db_name)
+        ReplicaPools.proxy(self, replica_pools_db_name)
       end
 
       def with_pool(*a)

--- a/lib/replica_pools/active_record_extensions.rb
+++ b/lib/replica_pools/active_record_extensions.rb
@@ -12,7 +12,7 @@ module ReplicaPools
     module ClassMethods
       def hijack_connection
         class << self
-          alias_method :connection, :connection_proxy
+          alias_method :connection, :connection_proxy if ReplicaPools.config.enabled?
         end
       end
 

--- a/lib/replica_pools/config.rb
+++ b/lib/replica_pools/config.rb
@@ -13,10 +13,19 @@ module ReplicaPools
     # Defaults are based on Rails version.
     attr_accessor :safe_methods
 
+    # When false, replica pools is completely disabled.
+    # Defaults to true
+    attr_accessor :enabled
+
     def initialize
       @environment        = 'development'
       @defaults_to_leader = false
       @safe_methods       = []
+      @enabled            = true
+    end
+
+    def enabled?
+      @enabled
     end
   end
 end

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -64,10 +64,6 @@ module ReplicaPools
       self.current = last_conn
     end
 
-    def transaction(*args, &block)
-      with_leader { leader.transaction(*args, &block) }
-    end
-
     def next_replica!
       return if within_leader_block?
       self.current = current_pool.next

--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -11,7 +11,11 @@ module ReplicaPools
           pools[db_name.to_sym][pool_name.to_sym] = ReplicaPools::Pool.new(
             pool_name,
             pool_set.map{ |conn_name, _, _, replica_name|
-              connection_class(db_name, pool_name, replica_name, conn_name)
+              connection_class(db_name, pool_name, replica_name, conn_name).tap do |connection|
+                if connection.connection_config['host']
+                  connection.connection.host_name = connection.connection_config['host']
+                end
+              end
             }
           )
         end

--- a/lib/replica_pools/pools.rb
+++ b/lib/replica_pools/pools.rb
@@ -16,12 +16,6 @@ module ReplicaPools
           )
         end
       end
-
-      if pools.empty?
-        ReplicaPools.log :info, "No pools found for #{ReplicaPools.config.environment}. Loading a default pool with leader instead."
-        pools[:default][:default] = ReplicaPools::Pool.new('default', [ActiveRecord::Base])
-      end
-
       super pools
     end
 

--- a/lib/replica_pools/query_cache.rb
+++ b/lib/replica_pools/query_cache.rb
@@ -12,7 +12,7 @@ module ReplicaPools
     (query_cache_methods - [:select_all]).each do |method_name|
       module_eval <<-END, __FILE__, __LINE__ + 1
         def #{method_name}(*a, &b)
-          ActiveRecord::Base.connection.#{method_name}(*a, &b)
+          route_to(leader, :#{method_name}, *a, &b)
         end
       END
     end


### PR DESCRIPTION
This PR adds multiple database support to replica_pools. It's completely **incompatible** change.

Here are major changes.

### database.yml naming

database.yml naming convention is changed to include database name.
`development_pool_default_name_replica1` → `development_db_userdb_pool_default_name_replica1`

### Per model applying

ReplicaPools has switched all of AR inherited models at once. This PR allows to apply the switching per model.

```ruby
# Only User model uses ReplicaPools and all other models aren't affected
class User < ActiveRecord::Base
  use_replica_pools :userdb
end
```

### Most of `ReplicaPools` class methods are moved to `ConnectionProxy`

Since ReplicaPools has multiple database group (master/slaves set), many class methods are moved to ConnectionProxy class.

```ruby
# before
ReplicaPools.with_pool { User.first }
ReplicaPools.next_replica!

# after
User.with_pool { User.first }
User.next_replica!
```