### PR TITLE
Support monkey patched AR methods

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -87,6 +87,10 @@ module ReplicaPools
       send(method, *args, &block)
     end
 
+    def respond_to_missing?(method, include_private)
+      true
+    end
+
     def within_leader_block?
       leader_depth > 0
     end

--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -88,7 +88,7 @@ module ReplicaPools
     end
 
     def respond_to_missing?(method, include_private)
-      true
+      leader.retrieve_connection.respond_to?(method) || super
     end
 
     def within_leader_block?


### PR DESCRIPTION
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter#executing-stored-procedures

activerecord-sqlserver-adapter adds `execute_procedure` to AR by monkey patch to support stored procedure call.
Since it uses `respond_to?` to check the method's existence, define `respond_to_missing?` to route stored procedure to leader server. (Rails can't know if the procedure is read only or not...)
https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/master/lib/active_record/connection_adapters/sqlserver/core_ext/active_record.rb#L12