### PR TITLE
Allow with_pool within with_leader switching to replica

### DIFF
--- a/lib/replica_pools/connection_proxy.rb
+++ b/lib/replica_pools/connection_proxy.rb
@@ -47,7 +47,7 @@ module ReplicaPools
     def with_pool(pool_name = 'default')
       last_conn, last_pool = self.current, self.current_pool
       self.current_pool = replica_pools[pool_name.to_sym] || default_pool
-      self.current = current_replica unless within_leader_block?
+      self.current = current_replica
       yield
     ensure
       self.current_pool = last_pool

--- a/spec/connection_proxy_spec.rb
+++ b/spec/connection_proxy_spec.rb
@@ -207,11 +207,12 @@ describe ReplicaPools do
       end
     end
 
-    it "should not switch to pool when nested inside with_leader" do
+    it "should switch to pool when nested inside with_leader" do
       @proxy.current.name.should eq('ReplicaPools::MainDefaultDb1')
       @proxy.with_leader do
+        @proxy.current.name.should eq('ActiveRecord::Base')
         @proxy.with_pool('secondary') do
-          @proxy.current.name.should eq('ActiveRecord::Base')
+          @proxy.current.name.should eq('ReplicaPools::MainSecondaryDb1')
         end
       end
     end


### PR DESCRIPTION
In our project, we use `around_action` for all POST/PUT/DELETE request to apply `with_leader` for entire action.
But sometimes, we want to use a replica even in the leader block since we are sure that the query isn't affected by replication delay.
To allow this use-case, allow using `with_pool` within `with_leader` block.